### PR TITLE
Revert to using PAT token for cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,4 +39,4 @@ jobs:
           commit: "[ci] release"
           title: "[ci] release"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_CONFORMAL }}


### PR DESCRIPTION
The release flow via changesets with automatic release PR creation is not working with the default `GITHUB_TOKEN`. Thus, revert to using a fine-grained personal access token.